### PR TITLE
Nettoyage des espaces de noms OpenCV et std

### DIFF
--- a/FaceRecognition/Camera.cpp
+++ b/FaceRecognition/Camera.cpp
@@ -4,9 +4,10 @@
 
 Camera::Camera()
 {
-	//On se connecte par défaut à la caméra
+void Camera::SetCapture(CvCapture* capture){_capture = capture;}
+
 	_capture = cvCaptureFromCAM(1);
-	if (!_capture)	// Si NoK alors on se connecte à la webcam
+	if (!_capture)	// Si NoK alors on se connecte Å• la webcam
 	{
 		_capture = cvCaptureFromCAM(0);
 	}

--- a/FaceRecognition/Camera.h
+++ b/FaceRecognition/Camera.h
@@ -2,8 +2,6 @@
 
 #include <opencv2/opencv.hpp>
 #include <iostream>
-using namespace cv;
-using namespace std;
 
 class Camera
 {

--- a/FaceRecognition/Histogram.cpp
+++ b/FaceRecognition/Histogram.cpp
@@ -5,7 +5,7 @@ Histogram::Histogram()
 {
 }
 
-Histogram::Histogram(Mat frame)
+Histogram::Histogram(cv::Mat frame)
 {
 	if (frame.empty())
 		return;
@@ -25,13 +25,13 @@ Histogram::~Histogram()
 {
 }
 
-void Histogram::CreateHistogrammeCouleur(Mat frame)
+void Histogram::CreateHistogrammeCouleur(cv::Mat frame)
 {
 	//Histogramme
 
 	/// Separate the image in 3 places ( B, G and R )
-	vector<Mat> bgr_planes;
-	split(frame, bgr_planes);
+	std::vector<cv::Mat> bgr_planes;
+	cv::split(frame, bgr_planes);
 
 	/// Establish the number of bins
 	int histSize = 256;
@@ -42,40 +42,40 @@ void Histogram::CreateHistogrammeCouleur(Mat frame)
 
 	bool uniform = true; bool accumulate = true;
 
-	Mat b_hist, g_hist, r_hist;
+	cv::Mat b_hist, g_hist, r_hist;
 
 	/// Compute the histograms:
-	calcHist(&bgr_planes[0], 1, 0, Mat(), b_hist, 1, &histSize, &histRange, uniform, accumulate);
-	calcHist(&bgr_planes[1], 1, 0, Mat(), g_hist, 1, &histSize, &histRange, uniform, accumulate);
-	calcHist(&bgr_planes[2], 1, 0, Mat(), r_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[0], 1, 0, cv::Mat(), b_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[1], 1, 0, cv::Mat(), g_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[2], 1, 0, cv::Mat(), r_hist, 1, &histSize, &histRange, uniform, accumulate);
 
 	// Draw the histograms for B, G and R
 	int hist_w = 512; int hist_h = 400;
 	int bin_w = cvRound(double(hist_w) / histSize);
 
-	Mat histImage(hist_h, hist_w, CV_8UC3, Scalar(0, 0, 0));
+	cv::Mat histImage(hist_h, hist_w, CV_8UC3, cv::Scalar(0, 0, 0));
 
 	/// Normalize the result to [ 0, histImage.rows ]
-	normalize(b_hist, b_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
-	normalize(g_hist, g_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
-	normalize(r_hist, r_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
+	cv::normalize(b_hist, b_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
+	cv::normalize(g_hist, g_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
+	cv::normalize(r_hist, r_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
 
 	/// Draw for each channel
 	for (int i = 1; i < histSize; i++)
 	{
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(b_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(b_hist.at<float>(i))),
-			Scalar(255, 0, 0), 2, 8, 0);
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(g_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(g_hist.at<float>(i))),
-			Scalar(0, 255, 0), 2, 8, 0);
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(r_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(r_hist.at<float>(i))),
-			Scalar(0, 0, 255), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(b_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(b_hist.at<float>(i))),
+			cv::Scalar(255, 0, 0), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(g_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(g_hist.at<float>(i))),
+			cv::Scalar(0, 255, 0), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(r_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(r_hist.at<float>(i))),
+			cv::Scalar(0, 0, 255), 2, 8, 0);
 	}
 	this->_graphHistogram = histImage;
 }
-void Histogram::CreateHistogrammeNDG(Mat frame)
+void Histogram::CreateHistogrammeNDG(cv::Mat frame)
 {
 	//Histogramme
 	/// Taile de l'histogramme
@@ -87,27 +87,27 @@ void Histogram::CreateHistogrammeNDG(Mat frame)
 
 	bool uniform = true; bool accumulate = true;
 
-	Mat ndg_hist;
+	cv::Mat ndg_hist;
 
 	/// Compute the histograms:
-	calcHist(&frame, 1, 0, Mat(), ndg_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&frame, 1, 0, cv::Mat(), ndg_hist, 1, &histSize, &histRange, uniform, accumulate);
 
 	// Draw the histogram
 	int hist_w = 512; int hist_h = 400;
 	int bin_w = cvRound((double)hist_w / histSize);
 
-	Mat histImage(hist_h, hist_w, CV_8UC3, Scalar(0, 0, 0));
+	cv::Mat histImage(hist_h, hist_w, CV_8UC3, cv::Scalar(0, 0, 0));
 
 	/// Normalize the result to [ 0, histImage.rows ]
-	normalize(ndg_hist, ndg_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
+	cv::normalize(ndg_hist, ndg_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
 
 
 	/// Draw for each channel
 	for (int i = 1; i < histSize; i++)
 	{
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(ndg_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(ndg_hist.at<float>(i))),
-			Scalar(255, 255, 255), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(ndg_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(ndg_hist.at<float>(i))),
+			cv::Scalar(255, 255, 255), 2, 8, 0);
 	}
 	this->_graphHistogram = histImage;
 	int const size = histSize;
@@ -116,3 +116,4 @@ void Histogram::CreateHistogrammeNDG(Mat frame)
 	//	this->_matriceHistogram[i] = cvRound(ndg_hist.at<float>(i));
 	int i =0;
 }
+

--- a/FaceRecognition/Histogram.h
+++ b/FaceRecognition/Histogram.h
@@ -1,25 +1,23 @@
 #pragma once
 #include <opencv2/opencv.hpp>
 #include <iostream>
-using namespace cv;
-using namespace std;
 
 class Histogram
 {
 public:
 	Histogram();
-	Histogram(Mat frame);
+	Histogram(cv::Mat frame);
 	~Histogram();
 
-	void CreateHistogrammeCouleur(Mat frame);
-	void CreateHistogrammeNDG(Mat frame);
+	void CreateHistogrammeCouleur(cv::Mat frame);
+	void CreateHistogrammeNDG(cv::Mat frame);
 
-	Mat get_graphHistogram() const
+	cv::Mat get_graphHistogram() const
 	{
 		return (_graphHistogram);
 	}
 private:
-	Mat _graphHistogram;
+	cv::Mat _graphHistogram;
 	int* _matriceHistogram;
 
 };

--- a/FaceRecognition/Image.cpp
+++ b/FaceRecognition/Image.cpp
@@ -16,7 +16,7 @@ Image::Image(Image& image)
 	this->_histogramLbp = image._histogramLbp;
 }
 
-Image::Image(Mat frame, bool convertToNdg = 0, bool convertToNdgAndEqualizeHistogram = 0, bool convertToLbp = 0, bool createHistogramColor = 0, bool createHistogramNdg = 0, bool createHistogramLbp = 0)
+Image::Image(cv::Mat frame, bool convertToNdg = 0, bool convertToNdgAndEqualizeHistogram = 0, bool convertToLbp = 0, bool createHistogramColor = 0, bool createHistogramNdg = 0, bool createHistogramLbp = 0)
 {
 	this->_frameCouleur = frame;
 	if (convertToNdg)
@@ -30,7 +30,7 @@ Image::Image(Mat frame, bool convertToNdg = 0, bool convertToNdgAndEqualizeHisto
 	if (createHistogramColor)
 		this->_histogramColor = *(new Histogram(this->_frameCouleur));
 }
-Image::Image(Mat frameLbp)
+Image::Image(cv::Mat frameLbp)
 {
 	this->_frameLbp = frameLbp;
 }
@@ -39,29 +39,29 @@ Image::~Image()
 {
 }
 
-Mat Image::ConvertToNdg(Mat frameColor, bool equalizeHistogram)
+cv::Mat Image::ConvertToNdg(cv::Mat frameColor, bool equalizeHistogram)
 {
-	Mat frameNdg;
-	cvtColor(frameColor, frameNdg, COLOR_BGR2GRAY);
+	cv::Mat frameNdg;
+	cv::cvtColor(frameColor, frameNdg, COLOR_BGR2GRAY);
 	if (equalizeHistogram)
 	{
-		GaussianBlur(frameNdg, frameNdg, Size(1, 1), 0, 0);
+		cv::GaussianBlur(frameNdg, frameNdg, cv::Size(1, 1), 0, 0);
 		//equalizeHist(frameNdg, frameNdg);
 		//normalize(frameNdg, frameNdg, 0, 255, NORM_MINMAX, CV_8UC1);
 	}
 	return (frameNdg);
 }
 
-Mat Image::ConvertToNdgFromNotColorImage(Mat frame, bool equalizeHistogram)
+cv::Mat Image::ConvertToNdgFromNotColorImage(cv::Mat frame, bool equalizeHistogram)
 {
-	Mat frameNdg;
+	cv::Mat frameNdg;
 	frame.convertTo(frameNdg, CV_8UC1);
 	return (frameNdg);
 }
 
-Mat Image::ConvertToLbp(Mat frameNdg)
+cv::Mat Image::ConvertToLbp(cv::Mat frameNdg)
 {
-	Mat frameLbp;
+	cv::Mat frameLbp;
 	//frameLbp =  Traitements::ELBP(frameNdg,1,4);
 	frameLbp = Traitements::LBP(frameNdg);
 
@@ -70,10 +70,10 @@ Mat Image::ConvertToLbp(Mat frameNdg)
 
 
 
-Mat Image::Normalize(Mat src) const
+cv::Mat Image::Normalize(cv::Mat src) const
 {
-	// Create and return normalized image:
-	Mat dst;
+        // Crée et renvoie une image normalisée :
+	cv::Mat dst;
 	switch (src.channels()) {
 	case 1:
 		cv::normalize(src, dst, 0, 255, NORM_MINMAX, CV_8UC1);
@@ -89,9 +89,10 @@ Mat Image::Normalize(Mat src) const
 }
 
 
-Mat Image::resize(Mat frame, Size size)
+cv::Mat Image::resize(cv::Mat frame, cv::Size size)
 {
-	Mat rezized;
+	cv::Mat rezized;
 	cv::resize(frame, rezized, size, 0, 0, INTER_LINEAR);
 	return(rezized);
 }
+

--- a/FaceRecognition/Image.h
+++ b/FaceRecognition/Image.h
@@ -2,47 +2,45 @@
 #include <opencv2/opencv.hpp>
 #include <iostream>
 #include "Histogram.h"
-using namespace cv;
-using namespace std;
 
 
 class Image
 {
-	Mat m;
+	cv::Mat m;
 public:
 	Image();
 	Image(Image&);
-	Image(Mat frame, bool convertToNdg, bool convertToNdgAndEqualizeHistogram, bool convertToLbp, bool createHistogramColor, bool createHistogramNdg, bool createHistogramLbp);
-	Image(Mat);
+	Image(cv::Mat frame, bool convertToNdg, bool convertToNdgAndEqualizeHistogram, bool convertToLbp, bool createHistogramColor, bool createHistogramNdg, bool createHistogramLbp);
+	Image(cv::Mat);
 	~Image();
 
-	static Mat ConvertToNdg(Mat frameColor, bool equalizeHistogram);
-	static Mat ConvertToNdgFromNotColorImage(Mat frame, bool equalizeHistogram);
-	Mat ConvertToLbp(Mat frameNdg);
-	Mat CreateLbpImage(Mat frame) const;
+	static cv::Mat ConvertToNdg(cv::Mat frameColor, bool equalizeHistogram);
+	static cv::Mat ConvertToNdgFromNotColorImage(cv::Mat frame, bool equalizeHistogram);
+	cv::Mat ConvertToLbp(cv::Mat frameNdg);
+	cv::Mat CreateLbpImage(cv::Mat frame) const;
 	template <class _Tp>
-	Mat CreateLbpImageExtended(const Mat& src, int radius, int neighbors);
-	Mat Normalize(const Mat src) const;
+	cv::Mat CreateLbpImageExtended(const cv::Mat& src, int radius, int neighbors);
+	cv::Mat Normalize(const cv::Mat src) const;
 	
 
-	static Mat resize(Mat frame, Size size);
-	Mat get_frameCouleur() 
+	static cv::Mat resize(cv::Mat frame, cv::Size size);
+	cv::Mat get_frameCouleur() 
 	{
 		return (_frameCouleur.empty() ? m : _frameCouleur);
 	}
-	Mat get_frameNdg() 
+	cv::Mat get_frameNdg() 
 	{
 		return (_frameNdg.empty() ? m : _frameNdg);
 	}
-	void set_frameNdg(Mat frameNdg)
+	void set_frameNdg(cv::Mat frameNdg)
 	{
 		this->_frameNdg = frameNdg;
 	}
-	Mat get_frameLbp() 
+	cv::Mat get_frameLbp() 
 	{
 		return (_frameLbp.empty() ? m : _frameLbp);
 	}
-	void set_frameLbp(Mat frameLbp)
+	void set_frameLbp(cv::Mat frameLbp)
 	{
 		this->_frameLbp = frameLbp;
 	}
@@ -72,9 +70,9 @@ public:
 	}
 
 private:
-	Mat _frameCouleur;
-	Mat _frameNdg;
-	Mat _frameLbp;
+	cv::Mat _frameCouleur;
+	cv::Mat _frameNdg;
+	cv::Mat _frameLbp;
 
 	Histogram _histogramNdg;
 	Histogram _histogramColor;

--- a/FaceRecognition/Traitements.cpp
+++ b/FaceRecognition/Traitements.cpp
@@ -5,13 +5,13 @@
 #endif 
 // Gestion Histogramme
 
-Mat Traitements::HistogrammeCouleur(Mat frame)
+cv::Mat Traitements::HistogrammeCouleur(cv::Mat frame)
 {
 	//Histogramme
 
 	/// Separate the image in 3 places ( B, G and R )
-	vector<Mat> bgr_planes;
-	split(frame, bgr_planes);
+	std::vector<cv::Mat> bgr_planes;
+	cv::split(frame, bgr_planes);
 
 	/// Establish the number of bins
 	int histSize = 256;
@@ -22,40 +22,40 @@ Mat Traitements::HistogrammeCouleur(Mat frame)
 
 	bool uniform = true; bool accumulate = true;
 
-	Mat b_hist, g_hist, r_hist;
+	cv::Mat b_hist, g_hist, r_hist;
 
 	/// Compute the histograms:
-	calcHist(&bgr_planes[0], 1, 0, Mat(), b_hist, 1, &histSize, &histRange, uniform, accumulate);
-	calcHist(&bgr_planes[1], 1, 0, Mat(), g_hist, 1, &histSize, &histRange, uniform, accumulate);
-	calcHist(&bgr_planes[2], 1, 0, Mat(), r_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[0], 1, 0, cv::Mat(), b_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[1], 1, 0, cv::Mat(), g_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&bgr_planes[2], 1, 0, cv::Mat(), r_hist, 1, &histSize, &histRange, uniform, accumulate);
 
 	// Draw the histograms for B, G and R
 	int hist_w = 512; int hist_h = 400;
 	int bin_w = cvRound(double(hist_w) / histSize);
 
-	Mat histImage(hist_h, hist_w, CV_8UC3, Scalar(0, 0, 0));
+	cv::Mat histImage(hist_h, hist_w, CV_8UC3, cv::Scalar(0, 0, 0));
 
 	/// Normalize the result to [ 0, histImage.rows ]
-	normalize(b_hist, b_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
-	normalize(g_hist, g_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
-	normalize(r_hist, r_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
+	cv::normalize(b_hist, b_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
+	cv::normalize(g_hist, g_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
+	cv::normalize(r_hist, r_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
 
 	/// Draw for each channel
 	for (int i = 1; i < histSize; i++)
 	{
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(b_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(b_hist.at<float>(i))),
-			Scalar(255, 0, 0), 2, 8, 0);
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(g_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(g_hist.at<float>(i))),
-			Scalar(0, 255, 0), 2, 8, 0);
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(r_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(r_hist.at<float>(i))),
-			Scalar(0, 0, 255), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(b_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(b_hist.at<float>(i))),
+			cv::Scalar(255, 0, 0), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(g_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(g_hist.at<float>(i))),
+			cv::Scalar(0, 255, 0), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(r_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(r_hist.at<float>(i))),
+			cv::Scalar(0, 0, 255), 2, 8, 0);
 	}
 	return(histImage);
 }
-Mat Traitements::HistogrammeNDG(Mat frame)
+cv::Mat Traitements::HistogrammeNDG(cv::Mat frame)
 {
 	//Histogramme
 	/// Taile de l'histogramme
@@ -67,34 +67,34 @@ Mat Traitements::HistogrammeNDG(Mat frame)
 
 	bool uniform = true; bool accumulate = true;
 
-	Mat ndg_hist;
+	cv::Mat ndg_hist;
 
 	/// Compute the histograms:
-	calcHist(&frame, 1, 0, Mat(), ndg_hist, 1, &histSize, &histRange, uniform, accumulate);
+	cv::calcHist(&frame, 1, 0, cv::Mat(), ndg_hist, 1, &histSize, &histRange, uniform, accumulate);
 
 	// Draw the histogram
 	int hist_w = 512; int hist_h = 400;
 	int bin_w = cvRound((double)hist_w / histSize);
 
-	Mat histImage(hist_h, hist_w, CV_8UC3, Scalar(0, 0, 0));
+	cv::Mat histImage(hist_h, hist_w, CV_8UC3, cv::Scalar(0, 0, 0));
 
 	/// Normalize the result to [ 0, histImage.rows ]
-	normalize(ndg_hist, ndg_hist, 0, histImage.rows, NORM_MINMAX, -1, Mat());
+	cv::normalize(ndg_hist, ndg_hist, 0, histImage.rows, NORM_MINMAX, -1, cv::Mat());
 
 
 	/// Draw for each channel
 	for (int i = 1; i < histSize; i++)
 	{
-		line(histImage, Point(bin_w*(i - 1), hist_h - cvRound(ndg_hist.at<float>(i - 1))),
-			Point(bin_w*(i), hist_h - cvRound(ndg_hist.at<float>(i))),
-			Scalar(255, 255, 255), 2, 8, 0);
+		cv::line(histImage, cv::Point(bin_w*(i - 1), hist_h - cvRound(ndg_hist.at<float>(i - 1))),
+			cv::Point(bin_w*(i), hist_h - cvRound(ndg_hist.at<float>(i))),
+			cv::Scalar(255, 255, 255), 2, 8, 0);
 	}
-	//Mat mat =
+	//cv::Mat mat =
 	/// Return
 	return histImage;
 }
-Mat Traitements::LBP(Mat img){
-	Mat dst = Mat::zeros(img.rows - 2, img.cols - 2, CV_8UC1);
+cv::Mat Traitements::LBP(cv::Mat img){
+	cv::Mat dst = cv::Mat::zeros(img.rows - 2, img.cols - 2, CV_8UC1);
 	for (int i = 1; i < img.rows - 1; i++) {
 		for (int j = 1; j < img.cols - 1; j++) {
 			uchar center = img.at<uchar>(i, j);
@@ -112,13 +112,13 @@ Mat Traitements::LBP(Mat img){
 	}
 	return dst;
 }
-Mat Traitements::ELBP(const Mat& src, int radius, int neighbors) {
-	neighbors = max(min(neighbors, 31), 1); // set bounds...
+cv::Mat Traitements::ELBP(const cv::Mat& src, int radius, int neighbors) {
+	neighbors = std::max(std::min(neighbors, 31), 1); // set bounds...
 	// Note: alternatively you can switch to the new OpenCV Mat_
 	// type system to define an unsigned int matrix... I am probably
 	// mistaken here, but I didn't see an unsigned int representation
 	// in OpenCV's classic typesystem...
-	 Mat dst = Mat::zeros(src.rows - 2 * radius, src.cols - 2 * radius, CV_32SC1);
+	 cv::Mat dst = cv::Mat::zeros(src.rows - 2 * radius, src.cols - 2 * radius, CV_32SC1);
 	for (int n = 0; n<neighbors; n++) {
 		// sample points
 		float x = static_cast<float>(radius)* cos(2.0*M_PI*n / static_cast<float>(neighbors));
@@ -141,7 +141,7 @@ Mat Traitements::ELBP(const Mat& src, int radius, int neighbors) {
 			for (int j = radius; j < src.cols - radius; j++) {
 				float t = w1*src.at<uchar>(i + fy, j + fx) + w2*src.at<uchar>(i + fy, j + cx) + w3*src.at<uchar>(i + cy, j + fx) + w4*src.at<uchar>(i + cy, j + cx);
 				// we are dealing with floating point precision, so add some little tolerance
-				dst.at<unsigned int>(i - radius, j - radius) += ((t > src.at<uchar>(i, j)) && (abs(t - src.at<uchar>(i, j)) > std::numeric_limits<float>::epsilon())) << n;
+				dst.at<unsigned int>(i - radius, j - radius) += ((t > src.at<uchar>(i, j)) && (cv::abs(t - src.at<uchar>(i, j)) > std::numeric_limits<float>::epsilon())) << n;
 			}
 		}
 	}
@@ -149,7 +149,7 @@ Mat Traitements::ELBP(const Mat& src, int radius, int neighbors) {
 }
 
 
-vector<int> Traitements::CreateHistograme(Mat image, bool isCumulated)
+std::vector<int> Traitements::CreateHistograme(cv::Mat image, bool isCumulated)
 {
 	std::vector<int> vector1(256, 0);
 	int with = image.size().width;
@@ -176,57 +176,58 @@ vector<int> Traitements::CreateHistograme(Mat image, bool isCumulated)
 }
 
 
-Mat Traitements::PreprocessingWithTanTrigs(InputArray src, float alpha, float tau, float gamma, int sigma0, int sigma1) 
+cv::Mat Traitements::PreprocessingWithTanTrigs(cv::InputArray src, float alpha, float tau, float gamma, int sigma0, int sigma1) 
 {
 
 	// Convert to floating point:
-	Mat X = src.getMat();
+	cv::Mat X = src.getMat();
 	X.convertTo(X, CV_32FC1);
 	// Start preprocessing:
-	Mat I;
-	pow(X, gamma, I);
+	cv::Mat I;
+	cv::pow(X, gamma, I);
 	// Calculate the DOG Image:
 	{
-		Mat gaussian0, gaussian1;
-		// Kernel Size:
+		cv::Mat gaussian0, gaussian1;
+		// Kernel cv::Size:
 		int kernel_sz0 = (3 * sigma0);
 		int kernel_sz1 = (3 * sigma1);
 		// Make them odd for OpenCV:
 		kernel_sz0 += ((kernel_sz0 % 2) == 0) ? 1 : 0;
 		kernel_sz1 += ((kernel_sz1 % 2) == 0) ? 1 : 0;
-		GaussianBlur(I, gaussian0, Size(kernel_sz0, kernel_sz0), sigma0, sigma0, BORDER_REPLICATE);
-		GaussianBlur(I, gaussian1, Size(kernel_sz1, kernel_sz1), sigma1, sigma1, BORDER_REPLICATE);
-		subtract(gaussian0, gaussian1, I);
+		cv::GaussianBlur(I, gaussian0, cv::Size(kernel_sz0, kernel_sz0), sigma0, sigma0, BORDER_REPLICATE);
+		cv::GaussianBlur(I, gaussian1, cv::Size(kernel_sz1, kernel_sz1), sigma1, sigma1, BORDER_REPLICATE);
+		cv::subtract(gaussian0, gaussian1, I);
 	}
 
 	{
 		double meanI = 0.0;
 		{
-			Mat tmp;
-			pow(abs(I), alpha, tmp);
-			meanI = mean(tmp).val[0];
+			cv::Mat tmp;
+			cv::pow(cv::abs(I), alpha, tmp);
+			meanI = cv::mean(tmp).val[0];
 
 		}
-		I = I / pow(meanI, 1.0 / alpha);
+		I = I / cv::pow(meanI, 1.0 / alpha);
 	}
 
 	{
 		double meanI = 0.0;
 		{
-			Mat tmp;
-			pow(min(abs(I), tau), alpha, tmp);
-			meanI = mean(tmp).val[0];
+			cv::Mat tmp;
+			cv::pow(cv::min(cv::abs(I), tau), alpha, tmp);
+			meanI = cv::mean(tmp).val[0];
 		}
-		I = I / pow(meanI, 1.0 / alpha);
+		I = I / cv::pow(meanI, 1.0 / alpha);
 	}
 
 	// Squash into the tanh:
 	{
-		Mat exp_x, exp_negx;
-		exp(I / tau, exp_x);
-		exp(-I / tau, exp_negx);
-		divide(exp_x - exp_negx, exp_x + exp_negx, I);
+		cv::Mat exp_x, exp_negx;
+		cv::exp(I / tau, exp_x);
+		cv::exp(-I / tau, exp_negx);
+		cv::divide(exp_x - exp_negx, exp_x + exp_negx, I);
 		I = tau * I;
 	}
 	return I;
 }
+

--- a/FaceRecognition/Traitements.h
+++ b/FaceRecognition/Traitements.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <opencv2/opencv.hpp>
 #include <iostream>
-using namespace cv;
-using namespace std;
 
 
 class Traitements
@@ -11,11 +9,11 @@ public:
 	Traitements();
 	~Traitements();
 	//Fonctions
-	static Mat HistogrammeCouleur(Mat);
-	static Mat HistogrammeNDG(Mat);
-	static Mat LBP(Mat);
-	static Mat ELBP(const Mat& src, int radius, int neighbors);
-	static vector<int> CreateHistograme(Mat, bool = false);
-	static Mat PreprocessingWithTanTrigs(InputArray src, float alpha = 0.1, float tau = 10.0, float gamma = 0.2, int sigma0 = 1, int sigma1 = 2);
+	static cv::Mat HistogrammeCouleur(cv::Mat);
+	static cv::Mat HistogrammeNDG(cv::Mat);
+	static cv::Mat LBP(cv::Mat);
+	static cv::Mat ELBP(const cv::Mat& src, int radius, int neighbors);
+	static std::vector<int> CreateHistograme(cv::Mat, bool = false);
+	static cv::Mat PreprocessingWithTanTrigs(cv::InputArray src, float alpha = 0.1, float tau = 10.0, float gamma = 0.2, int sigma0 = 1, int sigma1 = 2);
 };
 


### PR DESCRIPTION
## Summary
- retire les `using namespace` globaux des headers
- ajoute les préfixes `cv::` et `std::` dans les fichiers concernés

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855eccf1958832fa4c5aefb3df6bab7